### PR TITLE
Adding date/time of the generation, and link to up-to-date version list

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,12 +17,13 @@
   <div class="col-md-12">
     <p class="text-right">Jekyll version {{ jekyll.version }}</p>
     {% if site.github %}
-    <p>Current rubygems version in use at Github Pages are :</p>
+    <p>Versions of rubygems used at Github Pages when this page was generated ({{ site.time | date: '%F %T' }}):</p>
     <ul class="listToMargin">
     {% for gem in site.github.versions %}
     <li class="label label-info">{{ gem[0] }} {{ gem[1] }}</li>
     {% endfor %}
     </ul>
+    <p>Up-to-date version info is available at <a href="https://pages.github.com/versions/">https://pages.github.com/versions/</a></p>
     {% endif %}
   </div>
 </footer>


### PR DESCRIPTION
Fixes #1.

I have not tested these changes. I've just modified them using the GitHub web editor.

Also, I found your page because I wanted to understand why `ceil` was not working for me. Turns out it was because it was introduced in Jekyll/Liquid version 3, and I was running an older version.
